### PR TITLE
docs: Add section on dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,34 @@ Not all daemons are enabled and further work is necessary for full-compatibility
 You may install the system files via `sudo make install` and then copy the contents of `systemd/user` to `$HOME/.config/systemd/user` and adjust them for your personal needs.
 
 In your login manager `Sway (systemd)` should be startable as a new session.
+
+
+## Dependencies
+
+You need to manually install these dependencies first:
+
+ * swayidle - for idle management
+ * swaylock - for screen lock
+ * redshift - for automatic screen dimming
+ * policykit-1-gnome - privilege management
+ * mako - lightweight Wayland
+ * [kanshi](https://github.com/emersion/kanshi) - Dynamic display configuration for Wayland
+ * gnome-keyring - manage SSH keys, PKCS11 and other secrets
+ * gnome-session-bin - the gnome session binary itself
+ * gnome-settings-daemon-common - provides GNOME settings services. Services enabled here include:
+   * Accessibility Settings
+   * Color Management
+   * Date & Time handling
+   * Keyboard handling
+   * Media keys handling
+   * Power Management handling
+   * Printer Notifications
+   * Enabling and Disabling Wireless Devidces (rfkill)
+   * Screensaver handling
+   * Handle Sharing music, pictures and videos on the local network
+   * Enable Remote Login
+   * Smartcard handling
+   * Sound settings
+   * Wacom tablet handling
+   * WWAN handling for modems / SIM Cards
+   * X Server settings


### PR DESCRIPTION
This serves to both to show packages users may need to install first and also describes
what GNOME services are provided here.

