### PR TITLE
Make swaylock shortcut not conflict with default Sway configuration

### DIFF
--- a/sway/config.d/gnome
+++ b/sway/config.d/gnome
@@ -12,7 +12,7 @@ bindsym XF86AudioNext         exec playerctl next
 bindsym XF86AudioPrev         exec playerctl previous
 
 # Lockscreen
-bindsym $mod+l exec swaylock
+bindsym $mod+Escape exec swaylock
 # Desktop portal
 exec /usr/libexec/xdg-desktop-portal -r
 


### PR DESCRIPTION
This shortcut is consistent with Regolith, a Linux distro based on i3. Fixes  #4.

https://github.com/regolith-linux/regolith-i3-gaps-config/blob/master/config#L191