### PR TITLE
systemd: fail if "env" file is missing

### DIFF
--- a/systemd/user/sway.service
+++ b/systemd/user/sway.service
@@ -7,7 +7,7 @@ After=graphical-session-pre.target
 
 [Service]
 Type=simple
-EnvironmentFile=-%h/.config/sway/env
+EnvironmentFile=%h/.config/sway/env
 ExecStart=/usr/bin/sway
 Restart=on-failure
 RestartSec=1


### PR DESCRIPTION
The env file is essential for GNOME integration.

Before, the "-" before the path would cause sway to start but emit to
error, although something was badly wrong.

If for some reason you want a different behavior, you can use standard
system methods to override this configuration detail in the file or
the whole file.

Fixes #5