### PR TITLE
Fix: gnome-session-manager@sway-gnome.service pointing to invalid files

### DIFF
--- a/systemd/user/gnome-session-manager@sway-gnome.service
+++ b/systemd/user/gnome-session-manager@sway-gnome.service
@@ -9,5 +9,5 @@ After=sway.service
 
 [Service]
 Type=notify
-ExecStart=/usr/lib/gnome-session-binary --systemd-service --session=%i
-ExecStopPost=-/usr/lib/gnome-session-ctl --shutdown
+ExecStart=/usr/lib/gnome-session/gnome-session-binary --systemd-service --session=%i
+ExecStopPost=-/usr/lib/gnome-session/gnome-session-ctl --shutdown


### PR DESCRIPTION
Fixed ExecStart and ExecStopPost pointing to wrong binaries.
#12 